### PR TITLE
Add Open-Meteo API for Europe, expose for hubot-ollama tooling

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,26 +1,51 @@
 on:
   push:
-    branches: main
+    branches:
+      - main
 
 name: npm-publish
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm to latest version
+        run: npm install -g npm@latest
+
       - run: npm ci
       - run: npm test
-      - uses: JS-DevTools/npm-publish@v3
+
+      - name: Publish to npm
         id: publish
-        with:
-          token: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: |
+          # Verify npm version supports OIDC
+          echo "npm version: $(npm --version)"
+
+          # Check if version is already published
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version 2>/dev/null; then
+            echo "Version $PACKAGE_VERSION already published"
+            echo "type=" >> $GITHUB_OUTPUT
+          else
+            echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION..."
+            npm publish --access public
+            echo "type=patch" >> $GITHUB_OUTPUT
+            echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          fi
+
       - if: ${{ steps.publish.outputs.type }}
         name: Create Release
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubot-pollen
 
-Retrieves the latest forecast from the Pollen.com API.
+Retrieves the latest pollen forecast using Open-Meteo first, with fallback to Pollen.com when Open-Meteo has no usable pollen data.
 
 [![npm version](https://badge.fury.io/js/hubot-pollen.svg)](http://badge.fury.io/js/hubot-pollen) [![Node CI](https://github.com/stephenyeargin/hubot-pollen/actions/workflows/nodejs.yml/badge.svg)](https://github.com/stephenyeargin/hubot-pollen/actions/workflows/nodejs.yml)
 
@@ -20,19 +20,124 @@ Then add **hubot-pollen** to your `external-scripts.json`:
 
 ## Configuration
 
-Set the target location by provide a zip code. Defaults to Nashville, TN for demonstration purposes.
+Set the target location by providing a default search value (ZIP, city, or place text). Defaults to Nashville, TN for demonstration purposes.
 
-| Environment Variable  | Required? | Description                         |
-| --------------------- | :-------: | ----------------------------------- |
-| `HUBOT_POLLEN_ZIP`    | No        | The default zip code to query       |
+| Environment Variable          | Required? | Description                                                    |
+| ----------------------------- | :-------: | -------------------------------------------------------------- |
+| `HUBOT_POLLEN_ZIP`            | No        | Default location query (ZIP, city, or place)                   |
+| `HUBOT_POLLEN_OLLAMA_ENABLED` | No        | Set to `true` to register pollen tools with `hubot-ollama`     |
+
+## Commands
+
+- `hubot pollen` - Show today's pollen levels for the default location query.
+- `hubot pollen <zip>` - Show today's pollen levels for the given 5-digit ZIP.
+- `hubot pollen <search>` - Show today's pollen levels for a geocoded location query.
+
+## Data Source Strategy
+
+1. Query Open-Meteo geocoding with the provided location string.
+2. Query Open-Meteo air-quality pollen endpoint by coordinate.
+3. If Open-Meteo pollen values are all null (or otherwise unusable), fallback to Pollen.com using a 5-digit ZIP when available.
+
+Open-Meteo pollen values are only available for Europe during pollen season, so fallback is expected for many US locales.
+Slack responses cite Open-Meteo in the attachment footer when that data source is used.
 
 ## Sample Interaction
 
 ```
 user1>> hubot pollen
 hubot>> Nashville, TN Pollen: 8.2 (Medium-High) - Alder, Juniper, Maple
+
+user1>> hubot pollen London
+hubot>> London, GB Pollen: Low intensity (1.7 grains/m^3 peak) - Grass 1.7, Birch 0.6
 ```
 
 ## NPM Module
 
 https://www.npmjs.com/package/hubot-pollen
+
+## Ollama Integration
+
+This package can expose pollen tools to [Ollama](https://ollama.ai/) for use in LLM-powered conversations through the [hubot-ollama](https://github.com/stephenyeargin/hubot-ollama) package.
+
+### Enabling Ollama Tools
+
+To enable this feature, set the following environment variable:
+
+```bash
+HUBOT_POLLEN_OLLAMA_ENABLED=true
+```
+
+This requires hubot-ollama to be installed in your hubot repository. If hubot-ollama is not available, the tools will not be registered but the package will continue to function normally.
+
+### Available Tools
+
+#### get_pollen_forecast
+
+Retrieves pollen forecast data for a specified location.
+
+Parameters:
+- location (string, required): Location to get pollen forecast for. Can be a city name, city/state, city/country, or US ZIP code (for example, "Nashville, TN", "London", "37203").
+
+Returns:
+- Source used (open-meteo or pollen.com)
+- Location label
+- Coordinates when available
+- Intensity and peak concentration
+- Top pollen types when available
+
+#### get_pollen_by_coordinates
+
+Retrieves pollen forecast data for specific latitude and longitude coordinates.
+
+Parameters:
+- latitude (number, required): Latitude coordinate
+- longitude (number, required): Longitude coordinate
+
+Returns:
+- Source used (open-meteo)
+- Coordinates
+- Intensity and peak concentration
+- Top pollen types when available
+
+### Example Tool Response Shapes
+
+**`get_pollen_forecast`** — Open-Meteo result:
+```json
+{
+  "source": "open-meteo",
+  "location": "London, GB",
+  "coordinates": { "latitude": 51.5, "longitude": -0.1 },
+  "intensity": "Low",
+  "peak_grains_per_m3": 1.7,
+  "pollen_types": [
+    { "type": "Grass", "peak": 1.7 },
+    { "type": "Birch", "peak": 0.6 }
+  ]
+}
+```
+
+**`get_pollen_forecast`** — Pollen.com fallback result:
+```json
+{
+  "source": "pollen.com",
+  "location": "Nashville, TN",
+  "zip": "37206",
+  "index": 8.2,
+  "level": "Medium-High",
+  "triggers": ["Alder", "Juniper", "Maple"]
+}
+```
+
+**`get_pollen_by_coordinates`** result:
+```json
+{
+  "source": "open-meteo",
+  "coordinates": { "latitude": 51.5, "longitude": -0.1 },
+  "intensity": "Low",
+  "peak_grains_per_m3": 1.7,
+  "pollen_types": [
+    { "type": "Grass", "peak": 1.7 }
+  ]
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -435,6 +435,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1415,6 +1416,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5508,7 +5510,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -6224,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/src/ollama-tools.js
+++ b/src/ollama-tools.js
@@ -54,7 +54,7 @@ module.exports = (robot, {
         && forecast.Location.periods
         && forecast.Location.periods[1];
 
-      if (!period || !period.Index) {
+      if (!period || period.Index == null) {
         return {
           source: 'pollen.com',
           location: forecast.Location ? forecast.Location.DisplayLocation : 'Unknown',

--- a/src/ollama-tools.js
+++ b/src/ollama-tools.js
@@ -1,0 +1,243 @@
+// Description:
+//   Pollen tools for Ollama integration
+//
+// Configuration:
+//   HUBOT_POLLEN_OLLAMA_ENABLED  Set to 'true' to register pollen tools with hubot-ollama
+
+// eslint-disable-next-line default-param-last
+module.exports = (robot, {
+  getOpenMeteoGeocode,
+  getOpenMeteoForecast,
+  getPollenForecastData,
+  summarizeOpenMeteoPollen,
+  buildOpenMeteoLocationLabel,
+  extractFallbackZip,
+  formatIndexLabel,
+}, _registryForTest = null) => {
+  /**
+   * Register tools for Ollama integration if enabled
+   */
+  if (process.env.HUBOT_POLLEN_OLLAMA_ENABLED !== 'true') {
+    robot.logger.debug('Pollen Ollama tools disabled (set HUBOT_POLLEN_OLLAMA_ENABLED=true to enable)');
+    return;
+  }
+
+  robot.logger.info('Registering Pollen tools with Ollama');
+
+  try {
+    let registry;
+    if (_registryForTest) {
+      registry = _registryForTest;
+    } else {
+      // Resolve the registry once using explicit search paths for linked installs
+      // eslint-disable-next-line global-require
+      const path = require('path');
+      const registryPath = require.resolve('hubot-ollama/src/tool-registry', {
+        paths: [
+          __dirname,
+          path.resolve(__dirname, '../../node_modules'),
+          path.resolve(__dirname, '../../../node_modules'),
+          process.cwd(),
+        ],
+      });
+      // eslint-disable-next-line global-require, import/no-unresolved, import/no-dynamic-require
+      registry = require(registryPath);
+    }
+
+    robot.logger.info('Tool registry loaded successfully');
+
+    /**
+     * Helper: build a Pollen.com result object from a raw forecast response
+     */
+    const buildPollenComResult = (forecast) => {
+      const period = forecast.Location
+        && forecast.Location.periods
+        && forecast.Location.periods[1];
+
+      if (!period || !period.Index) {
+        return {
+          source: 'pollen.com',
+          location: forecast.Location ? forecast.Location.DisplayLocation : 'Unknown',
+          error: 'No forecast available',
+        };
+      }
+
+      const triggers = period.Triggers
+        ? Object.values(period.Triggers).filter((t) => t && t.Name).map((t) => t.Name)
+        : [];
+
+      return {
+        source: 'pollen.com',
+        location: forecast.Location.DisplayLocation,
+        zip: forecast.Location.ZIP,
+        index: period.Index,
+        level: formatIndexLabel(period.Index),
+        triggers,
+      };
+    };
+
+    /**
+     * Tool: get_pollen_forecast
+     * Geocodes a location string then queries Open-Meteo for pollen data,
+     * falling back to Pollen.com when a US ZIP is available.
+     */
+    const pollenForecastTool = {
+      description: 'Get the current pollen forecast for a location. Returns pollen intensity, peak concentration, and active pollen types. Uses Open-Meteo as the primary source with automatic fallback to Pollen.com for US ZIP codes when Open-Meteo has no data.',
+      parameters: {
+        type: 'object',
+        required: ['location'],
+        properties: {
+          location: {
+            type: 'string',
+            description: 'Location to get pollen forecast for. Can be a city name, city/state, city/country, or US ZIP code (e.g., "Nashville, TN", "London", "37203").',
+          },
+        },
+      },
+      handler: async ({ location }) => new Promise((resolve, reject) => {
+        const query = `${location}`.trim();
+        const fallbackZipFromQuery = extractFallbackZip(query, null);
+
+        getOpenMeteoGeocode(query, (geocodeErr, geoLocation) => {
+          if (geocodeErr) {
+            robot.logger.debug(`Geocoding failed for "${query}":`, geocodeErr.message);
+
+            if (fallbackZipFromQuery) {
+              getPollenForecastData(fallbackZipFromQuery, (pollenErr, forecast) => {
+                if (pollenErr) {
+                  reject(new Error(`Could not retrieve pollen data: ${pollenErr.message}`));
+                  return;
+                }
+                resolve(buildPollenComResult(forecast));
+              });
+              return;
+            }
+
+            reject(new Error(`Could not find location: ${location}`));
+            return;
+          }
+
+          const fallbackZip = extractFallbackZip(query, geoLocation);
+
+          getOpenMeteoForecast(geoLocation, (forecastErr, forecast) => {
+            if (!forecastErr) {
+              const summary = summarizeOpenMeteoPollen(forecast);
+              if (summary) {
+                robot.logger.debug('Open-Meteo pollen result:', summary);
+                resolve({
+                  source: 'open-meteo',
+                  location: buildOpenMeteoLocationLabel(geoLocation),
+                  coordinates: {
+                    latitude: geoLocation.latitude,
+                    longitude: geoLocation.longitude,
+                  },
+                  intensity: summary.intensity,
+                  peak_grains_per_m3: summary.topPeak,
+                  pollen_types: summary.entries.map((e) => ({ type: e.label, peak: e.peak })),
+                });
+                return;
+              }
+            }
+
+            if (fallbackZip) {
+              robot.logger.debug('Open-Meteo had no usable pollen data, falling back to Pollen.com', { fallbackZip });
+              getPollenForecastData(fallbackZip, (pollenErr, pollenForecast) => {
+                if (pollenErr) {
+                  reject(new Error(`Could not retrieve pollen data: ${pollenErr.message}`));
+                  return;
+                }
+                resolve(buildPollenComResult(pollenForecast));
+              });
+              return;
+            }
+
+            if (forecastErr) {
+              reject(new Error(`Could not retrieve pollen forecast: ${forecastErr.message}`));
+              return;
+            }
+
+            // Open-Meteo geocoded but returned no usable pollen and no ZIP fallback available
+            resolve({
+              source: 'open-meteo',
+              location: buildOpenMeteoLocationLabel(geoLocation),
+              coordinates: {
+                latitude: geoLocation.latitude,
+                longitude: geoLocation.longitude,
+              },
+              intensity: 'None',
+              peak_grains_per_m3: 0,
+              pollen_types: [],
+            });
+          });
+        });
+      }),
+    };
+
+    registry.registerTool('get_pollen_forecast', pollenForecastTool);
+    robot.logger.info('Registered get_pollen_forecast tool');
+
+    /**
+     * Tool: get_pollen_by_coordinates
+     * Queries Open-Meteo directly for pollen data at given coordinates.
+     */
+    const pollenByCoordinatesTool = {
+      description: 'Get the current pollen forecast for specific geographic coordinates using Open-Meteo. Returns pollen intensity, peak concentration, and active pollen types. Useful when you already have latitude and longitude.',
+      parameters: {
+        type: 'object',
+        required: ['latitude', 'longitude'],
+        properties: {
+          latitude: {
+            type: 'number',
+            description: 'Latitude coordinate',
+          },
+          longitude: {
+            type: 'number',
+            description: 'Longitude coordinate',
+          },
+        },
+      },
+      handler: async ({ latitude, longitude }) => new Promise((resolve, reject) => {
+        const coords = { latitude, longitude };
+
+        getOpenMeteoForecast(coords, (err, forecast) => {
+          if (err) {
+            reject(new Error(`Could not retrieve pollen forecast: ${err.message}`));
+            return;
+          }
+
+          const summary = summarizeOpenMeteoPollen(forecast);
+          if (!summary) {
+            resolve({
+              source: 'open-meteo',
+              coordinates: { latitude, longitude },
+              intensity: 'None',
+              peak_grains_per_m3: 0,
+              pollen_types: [],
+            });
+            return;
+          }
+
+          robot.logger.debug('Open-Meteo coordinate pollen result:', summary);
+          resolve({
+            source: 'open-meteo',
+            coordinates: { latitude, longitude },
+            intensity: summary.intensity,
+            peak_grains_per_m3: summary.topPeak,
+            pollen_types: summary.entries.map((e) => ({ type: e.label, peak: e.peak })),
+          });
+        });
+      }),
+    };
+
+    registry.registerTool('get_pollen_by_coordinates', pollenByCoordinatesTool);
+    robot.logger.info('Registered get_pollen_by_coordinates tool');
+
+    robot.logger.info('Pollen tools registered with Ollama');
+  } catch (err) {
+    // hubot-ollama not installed, silently ignore
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      robot.logger.error(`Failed to register Pollen tools with Ollama: ${err.message}`, err);
+    } else {
+      robot.logger.debug('hubot-ollama not installed, skipping Ollama tool registration');
+    }
+  }
+};

--- a/src/pollen.js
+++ b/src/pollen.js
@@ -1,12 +1,15 @@
 // Description:
-//   Retrieves the latest pollen forecast from Pollen.com
+//   Retrieves the latest pollen forecast using Open-Meteo first,
+//   with fallback to Pollen.com when needed.
 //
 // Configuration:
-//   HUBOT_POLLEN_ZIP  Default ZIP code to use when none is provided (e.g., 37203)
+//   HUBOT_POLLEN_ZIP            - Default location query when none is provided (e.g., 37203, London)
+//   HUBOT_POLLEN_OLLAMA_ENABLED - Set to 'true' to register pollen tools with hubot-ollama
 //
 // Commands:
-//   hubot pollen            - Show today's pollen levels for the default ZIP
+//   hubot pollen            - Show today's pollen levels for the default location query
 //   hubot pollen <zip>      - Show today's pollen levels for the given 5-digit ZIP
+//   hubot pollen <search>   - Show today's pollen levels for a geocoded location query
 //
 // Author:
 //   stephenyeargin
@@ -14,6 +17,112 @@
 const dayjs = require('dayjs');
 
 module.exports = (robot) => {
+  const usStateNamesByAbbreviation = {
+    AL: 'Alabama',
+    AK: 'Alaska',
+    AZ: 'Arizona',
+    AR: 'Arkansas',
+    CA: 'California',
+    CO: 'Colorado',
+    CT: 'Connecticut',
+    DE: 'Delaware',
+    FL: 'Florida',
+    GA: 'Georgia',
+    HI: 'Hawaii',
+    ID: 'Idaho',
+    IL: 'Illinois',
+    IN: 'Indiana',
+    IA: 'Iowa',
+    KS: 'Kansas',
+    KY: 'Kentucky',
+    LA: 'Louisiana',
+    ME: 'Maine',
+    MD: 'Maryland',
+    MA: 'Massachusetts',
+    MI: 'Michigan',
+    MN: 'Minnesota',
+    MS: 'Mississippi',
+    MO: 'Missouri',
+    MT: 'Montana',
+    NE: 'Nebraska',
+    NV: 'Nevada',
+    NH: 'New Hampshire',
+    NJ: 'New Jersey',
+    NM: 'New Mexico',
+    NY: 'New York',
+    NC: 'North Carolina',
+    ND: 'North Dakota',
+    OH: 'Ohio',
+    OK: 'Oklahoma',
+    OR: 'Oregon',
+    PA: 'Pennsylvania',
+    RI: 'Rhode Island',
+    SC: 'South Carolina',
+    SD: 'South Dakota',
+    TN: 'Tennessee',
+    TX: 'Texas',
+    UT: 'Utah',
+    VT: 'Vermont',
+    VA: 'Virginia',
+    WA: 'Washington',
+    WV: 'West Virginia',
+    WI: 'Wisconsin',
+    WY: 'Wyoming',
+    DC: 'District of Columbia',
+  };
+  const countryCodeAliases = {
+    UK: 'GB',
+    GBR: 'GB',
+    USA: 'US',
+  };
+  const countryNameToCode = {
+    austria: 'AT',
+    belgium: 'BE',
+    bulgaria: 'BG',
+    croatia: 'HR',
+    cyprus: 'CY',
+    czechia: 'CZ',
+    'czech republic': 'CZ',
+    denmark: 'DK',
+    estonia: 'EE',
+    finland: 'FI',
+    france: 'FR',
+    germany: 'DE',
+    greece: 'GR',
+    hungary: 'HU',
+    ireland: 'IE',
+    italy: 'IT',
+    latvia: 'LV',
+    lithuania: 'LT',
+    luxembourg: 'LU',
+    malta: 'MT',
+    netherlands: 'NL',
+    norway: 'NO',
+    poland: 'PL',
+    portugal: 'PT',
+    romania: 'RO',
+    slovakia: 'SK',
+    slovenia: 'SI',
+    spain: 'ES',
+    sweden: 'SE',
+    switzerland: 'CH',
+    'united kingdom': 'GB',
+    england: 'GB',
+    scotland: 'GB',
+    wales: 'GB',
+    'northern ireland': 'GB',
+    uk: 'GB',
+  };
+  const openMeteoGeocodeApiUrl = 'https://geocoding-api.open-meteo.com/v1/search';
+  const openMeteoAirQualityApiUrl = 'https://air-quality-api.open-meteo.com/v1/air-quality';
+  const openMeteoPollenTypes = [
+    { key: 'alder_pollen', label: 'Alder' },
+    { key: 'birch_pollen', label: 'Birch' },
+    { key: 'grass_pollen', label: 'Grass' },
+    { key: 'mugwort_pollen', label: 'Mugwort' },
+    { key: 'olive_pollen', label: 'Olive' },
+    { key: 'ragweed_pollen', label: 'Ragweed' },
+  ];
   const apiUrl = 'https://www.pollen.com/api/forecast/current/pollen';
   const webUrl = 'https://www.pollen.com/forecast/current/pollen';
   const userAgentString = 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:75.0) Gecko/20100101 Firefox/75.0';
@@ -150,7 +259,349 @@ module.exports = (robot) => {
     return payload;
   };
 
-  const getPollenForecast = (zip, msg) => {
+  const extractZipFromText = (text) => {
+    const value = `${text || ''}`.trim();
+    const match = value.match(/\b([0-9]{5})\b/);
+    return match ? match[1] : null;
+  };
+
+  const extractFallbackZip = (query, location) => {
+    const fromQuery = extractZipFromText(query);
+    if (fromQuery) {
+      return fromQuery;
+    }
+
+    if (location && Array.isArray(location.postcodes)) {
+      for (let i = 0; i < location.postcodes.length; i += 1) {
+        const postcode = extractZipFromText(location.postcodes[i]);
+        if (postcode) {
+          return postcode;
+        }
+      }
+    }
+
+    return null;
+  };
+
+  const buildOpenMeteoLocationLabel = (location) => {
+    const countryCode = `${location.country_code || ''}`.toUpperCase();
+    if (countryCode === 'US' && location.admin1) {
+      return `${location.name}, ${location.admin1}`;
+    }
+
+    if (countryCode && location.name) {
+      return `${location.name}, ${countryCode}`;
+    }
+
+    return location.name || 'Unknown';
+  };
+
+  const formatOpenMeteoIntensity = (index) => {
+    if (index <= 0.1) {
+      return 'None';
+    }
+    if (index <= 1.0) {
+      return 'Very Low';
+    }
+    if (index <= 5.0) {
+      return 'Low';
+    }
+    if (index <= 20.0) {
+      return 'Moderate';
+    }
+    return 'High';
+  };
+
+  const formatOpenMeteoColor = (index) => {
+    if (index <= 1.0) {
+      return 'good';
+    }
+    if (index <= 5.0) {
+      return 'warning';
+    }
+    return 'danger';
+  };
+
+  const summarizeOpenMeteoPollen = (forecast) => {
+    const hourly = forecast && forecast.hourly ? forecast.hourly : null;
+    if (!hourly) {
+      return null;
+    }
+
+    const peaks = openMeteoPollenTypes.map((type) => {
+      const values = Array.isArray(hourly[type.key]) ? hourly[type.key] : [];
+      const numericValues = values.filter((value) => Number.isFinite(value));
+      const peak = numericValues.length ? Math.max(...numericValues) : null;
+      return {
+        label: type.label,
+        peak,
+      };
+    });
+
+    const hasNumericData = peaks.some((row) => Number.isFinite(row.peak));
+    if (!hasNumericData) {
+      return null;
+    }
+
+    const sortedPeaks = peaks
+      .filter((row) => Number.isFinite(row.peak))
+      .sort((a, b) => b.peak - a.peak);
+
+    const topPositivePeaks = sortedPeaks.filter((row) => row.peak > 0).slice(0, 3);
+    const displayPeaks = topPositivePeaks.length > 0 ? topPositivePeaks : sortedPeaks.slice(0, 3);
+    const topPeak = sortedPeaks.length > 0 ? sortedPeaks[0].peak : 0;
+
+    return {
+      topPeak,
+      intensity: formatOpenMeteoIntensity(topPeak),
+      entries: displayPeaks,
+      hasPositivePollen: topPositivePeaks.length > 0,
+    };
+  };
+
+  const formatOpenMeteoForecast = (location, forecast) => {
+    const summary = summarizeOpenMeteoPollen(forecast);
+    if (!summary) {
+      return null;
+    }
+
+    const locationLabel = buildOpenMeteoLocationLabel(location);
+    const isSlack = robot.adapterName?.includes('slack') || robot.adapter?.constructor?.name === 'SlackBot';
+    const intensity = summary.intensity;
+    const count = summary.topPeak.toFixed(1);
+    const types = summary.hasPositivePollen
+      ? summary.entries.map((entry) => `${entry.label} ${entry.peak.toFixed(1)}`).join(', ')
+      : 'No measurable pollen detected today.';
+
+    if (isSlack) {
+      return {
+        attachments: [
+          {
+            fallback: `${locationLabel} Pollen: ${intensity} intensity (${count} grains/m^3 peak) - ${types}`,
+            title: `${locationLabel} Pollen`,
+            title_link: 'https://open-meteo.com/en/docs/air-quality-api',
+            author_name: 'Open-Meteo',
+            author_link: 'https://open-meteo.com/',
+            footer: 'Data: Open-Meteo',
+            color: formatOpenMeteoColor(summary.topPeak),
+            fields: [
+              {
+                title: 'Intensity',
+                value: `${intensity} (Open-Meteo model scale)`,
+                short: true,
+              },
+              {
+                title: 'Peak',
+                value: `${count} grains/m^3`,
+                short: true,
+              },
+              {
+                title: 'Types',
+                value: types,
+                short: false,
+              },
+            ],
+            ts: dayjs().unix(),
+          },
+        ],
+      };
+    }
+
+    return `${locationLabel} Pollen: ${intensity} intensity (${count} grains/m^3 peak) - ${types}`;
+  };
+
+  const sendFriendlyNoDataMessage = (msg, query, location) => {
+    const trimmedQuery = `${query || ''}`.trim();
+    if (location) {
+      const locationLabel = buildOpenMeteoLocationLabel(location);
+      msg.send(`No usable Open-Meteo pollen forecast is currently available for ${locationLabel}. Try a nearby city or provide a postal code for fallback.`);
+      return;
+    }
+
+    msg.send(`I couldn't find a location match for "${trimmedQuery}". Try a simpler place name (for example, "London") or a 5-digit ZIP for US fallback.`);
+  };
+
+  const getOpenMeteoGeocode = (query, cb) => {
+    const isExactZip = /^[0-9]{5}$/.test(`${query}`.trim());
+    const sanitized = `${query || ''}`
+      .trim()
+      .replace(/\s+/g, ' ');
+    const supportedCountryCodes = new Set([
+      ...Object.values(countryCodeAliases),
+      ...Object.values(countryNameToCode),
+    ]);
+    const preferredAttempts = [];
+    const fallbackAttempts = [];
+    const seen = new Set();
+    const normalizeRegionText = (value) => `${value || ''}`
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '');
+
+    const addAttempt = (name, countryCode, preferred, expectedAdmin1) => {
+      const cleanName = `${name || ''}`.trim().replace(/\s+/g, ' ');
+      if (!cleanName) {
+        return;
+      }
+
+      const key = `${cleanName.toLowerCase()}|${(countryCode || '').toUpperCase()}`;
+      if (seen.has(key)) {
+        return;
+      }
+
+      seen.add(key);
+      const target = {
+        name: cleanName,
+        countryCode: countryCode || null,
+        expectedAdmin1: Array.isArray(expectedAdmin1) ? expectedAdmin1 : (expectedAdmin1 ? [expectedAdmin1] : null),
+      };
+
+      if (preferred) {
+        preferredAttempts.push(target);
+      } else {
+        fallbackAttempts.push(target);
+      }
+    };
+
+    addAttempt(sanitized, null, false);
+
+    if (!isExactZip) {
+      addAttempt(sanitized.replace(/,/g, ' '), null, false);
+      addAttempt(sanitized.replace(/[^a-zA-Z0-9\s]/g, ' '), null, false);
+
+      const commaRegionMatch = sanitized.match(/^(.+?),\s*([a-zA-Z]{2,3})$/);
+      if (commaRegionMatch) {
+        const city = commaRegionMatch[1].trim();
+        const regionToken = commaRegionMatch[2].toUpperCase();
+        const stateName = usStateNamesByAbbreviation[regionToken];
+        const isKnownCountryCode = supportedCountryCodes.has(regionToken);
+
+        if (stateName && isKnownCountryCode) {
+          addAttempt(`${city} ${regionToken}`, regionToken, true);
+          addAttempt(city, regionToken, true);
+          addAttempt(`${city} ${regionToken}`, 'US', true, [stateName, regionToken]);
+          addAttempt(`${city} ${stateName}`, 'US', true, [stateName, regionToken]);
+          addAttempt(city, 'US', true, [stateName, regionToken]);
+        } else if (stateName) {
+          addAttempt(`${city} ${regionToken}`, 'US', true, [stateName, regionToken]);
+          addAttempt(`${city} ${stateName}`, 'US', true, [stateName, regionToken]);
+          addAttempt(city, 'US', true, [stateName, regionToken]);
+        } else {
+          const normalizedCountryCode = countryCodeAliases[regionToken] || regionToken;
+          addAttempt(`${city} ${normalizedCountryCode}`, normalizedCountryCode, true);
+          addAttempt(city, normalizedCountryCode, true);
+        }
+      }
+
+      const commaCountryNameMatch = sanitized.match(/^(.+?),\s*([a-zA-Z][a-zA-Z\s'-]+)$/);
+      if (commaCountryNameMatch) {
+        const city = commaCountryNameMatch[1].trim();
+        const rawCountryName = commaCountryNameMatch[2].trim().toLowerCase();
+        const normalizedCountryName = rawCountryName.replace(/\s+/g, ' ');
+        const countryCode = countryNameToCode[normalizedCountryName];
+
+        if (countryCode) {
+          addAttempt(`${city} ${countryCode}`, countryCode, true);
+          addAttempt(city, countryCode, true);
+        }
+      }
+    }
+
+    const attempts = [...preferredAttempts, ...fallbackAttempts];
+
+    const tryAttempt = (index) => {
+      if (index >= attempts.length) {
+        const error = new Error(`Open-Meteo could not geocode "${query}"`);
+        error.code = 'GEOCODE_NOT_FOUND';
+        cb(error);
+        return;
+      }
+
+      const attempt = attempts[index];
+      let geocodeUrl = `${openMeteoGeocodeApiUrl}?name=${encodeURIComponent(attempt.name)}&count=10&language=en&format=json`;
+      if (attempt.countryCode) {
+        geocodeUrl += `&countryCode=${encodeURIComponent(attempt.countryCode)}`;
+      }
+
+      robot.http(geocodeUrl)
+        .timeout(1000)
+        .get()((err, res, body) => {
+          if (err) {
+            cb(err);
+            return;
+          }
+
+          if (!res || res.statusCode !== 200) {
+            cb(new Error(`Open-Meteo geocoding HTTP ${res ? res.statusCode : 'unknown'}`));
+            return;
+          }
+
+          let payload;
+          try {
+            payload = JSON.parse(body);
+          } catch (parseError) {
+            cb(new Error(`Open-Meteo geocoding parse error: ${parseError.message}`));
+            return;
+          }
+
+          if (payload.results && payload.results.length > 0) {
+            const matchingResult = payload.results.find((result) => {
+              if (attempt.expectedAdmin1) {
+                const actualAdmin = normalizeRegionText(result.admin1);
+                return attempt.expectedAdmin1.some((expectedValue) => {
+                  const expectedAdmin = normalizeRegionText(expectedValue);
+                  return expectedAdmin === actualAdmin;
+                });
+              }
+
+              return true;
+            });
+
+            if (matchingResult) {
+              cb(null, matchingResult);
+              return;
+            }
+
+            tryAttempt(index + 1);
+            return;
+          }
+
+          tryAttempt(index + 1);
+        });
+    };
+
+    tryAttempt(0);
+  };
+
+  const getOpenMeteoForecast = (location, cb) => {
+    const hourly = openMeteoPollenTypes.map((type) => type.key).join(',');
+    const airQualityUrl = `${openMeteoAirQualityApiUrl}?latitude=${location.latitude}&longitude=${location.longitude}&hourly=${hourly}&forecast_days=1&timezone=auto`;
+
+    robot.http(airQualityUrl)
+      .timeout(1000)
+      .get()((err, res, body) => {
+        if (err) {
+          cb(err);
+          return;
+        }
+
+        if (!res || res.statusCode !== 200) {
+          cb(new Error(`Open-Meteo air-quality HTTP ${res ? res.statusCode : 'unknown'}`));
+          return;
+        }
+
+        let payload;
+        try {
+          payload = JSON.parse(body);
+        } catch (parseError) {
+          cb(new Error(`Open-Meteo air-quality parse error: ${parseError.message}`));
+          return;
+        }
+
+        cb(null, payload);
+      });
+  };
+
+  const getPollenForecastData = (zip, cb) => {
     robot.logger.debug('zip', zip);
     const requestHeaders = {
       'User-Agent': userAgentString,
@@ -161,37 +612,99 @@ module.exports = (robot) => {
       .headers(requestHeaders)
       .get()((err, res, body) => {
         if (err) {
-          handleError(err, msg);
+          cb(err);
           return;
         }
-        try {
-          if (res.statusCode !== 200) {
-            handleError(`Server responded with HTTP ${res.statusCode}`, msg);
-            return;
-          }
-
-          let forecast;
-          try {
-            forecast = JSON.parse(body);
-          } catch (parseError) {
-            handleError(`Error parsing JSON response: ${parseError}`, msg);
-            return;
-          }
-
-          robot.logger.debug('forecast', forecast);
-
-          const formattedMessage = formatForecast(forecast);
-          robot.logger.debug('formattedMessage type', typeof formattedMessage);
-          robot.logger.debug('formattedMessage', formattedMessage);
-          
-          msg.send(formattedMessage);
-        } catch (e) {
-          handleError(`Unexpected error: ${e.message}`, msg);
+        if (res.statusCode !== 200) {
+          cb(new Error(`Server responded with HTTP ${res.statusCode}`));
+          return;
         }
+        let forecast;
+        try {
+          forecast = JSON.parse(body);
+        } catch (parseError) {
+          cb(new Error(`Error parsing JSON response: ${parseError}`));
+          return;
+        }
+        robot.logger.debug('forecast', forecast);
+        cb(null, forecast);
       });
   };
 
-  robot.respond(/pollen$/i, (msg) => getPollenForecast(defaultZipCode, msg));
+  const getPollenForecast = (zip, msg) => {
+    getPollenForecastData(zip, (err, forecast) => {
+      if (err) {
+        handleError(err.message, msg);
+        return;
+      }
+      const formattedMessage = formatForecast(forecast);
+      robot.logger.debug('formattedMessage type', typeof formattedMessage);
+      robot.logger.debug('formattedMessage', formattedMessage);
+      msg.send(formattedMessage);
+    });
+  };
 
-  robot.respond(/pollen ([0-9]{5})$/i, (msg) => getPollenForecast(msg.match[1], msg));
+  const getForecast = (query, msg) => {
+    const locationQuery = `${query}`.trim();
+    const fallbackZipFromQuery = extractFallbackZip(locationQuery, null);
+
+    getOpenMeteoGeocode(locationQuery, (geocodeErr, location) => {
+      if (geocodeErr) {
+        robot.logger.debug('Open-Meteo geocode failed, attempting fallback', geocodeErr);
+        if (fallbackZipFromQuery) {
+          getPollenForecast(fallbackZipFromQuery, msg);
+          return;
+        }
+
+        if (geocodeErr.code === 'GEOCODE_NOT_FOUND') {
+          sendFriendlyNoDataMessage(msg, locationQuery, null);
+          return;
+        }
+
+        handleError(geocodeErr.message, msg);
+        return;
+      }
+
+      const fallbackZip = extractFallbackZip(locationQuery, location);
+      getOpenMeteoForecast(location, (openMeteoErr, forecast) => {
+        if (!openMeteoErr) {
+          const formattedMessage = formatOpenMeteoForecast(location, forecast);
+          if (formattedMessage) {
+            msg.send(formattedMessage);
+            return;
+          }
+        }
+
+        if (fallbackZip) {
+          robot.logger.debug('Open-Meteo had no usable pollen data, falling back to Pollen.com', {
+            fallbackZip,
+          });
+          getPollenForecast(fallbackZip, msg);
+          return;
+        }
+
+        if (openMeteoErr) {
+          handleError(openMeteoErr.message, msg);
+          return;
+        }
+
+        sendFriendlyNoDataMessage(msg, locationQuery, location);
+      });
+    });
+  };
+
+  robot.respond(/pollen$/i, (msg) => getForecast(defaultZipCode, msg));
+
+  robot.respond(/pollen (.+)$/i, (msg) => getForecast(msg.match[1], msg));
+
+  // eslint-disable-next-line global-require
+  require('./ollama-tools')(robot, {
+    getOpenMeteoGeocode,
+    getOpenMeteoForecast,
+    getPollenForecastData,
+    summarizeOpenMeteoPollen,
+    buildOpenMeteoLocationLabel,
+    extractFallbackZip,
+    formatIndexLabel,
+  });
 };

--- a/test/ollama-tools-test.js
+++ b/test/ollama-tools-test.js
@@ -1,0 +1,362 @@
+/* global describe before beforeEach afterEach it */
+/* eslint-disable func-names */
+const assert = require('assert');
+const sinon = require('sinon');
+
+const buildOpenMeteoGoodForecast = () => ({
+  hourly: {
+    alder_pollen: [0.0, 0.0],
+    birch_pollen: [0.1, 0.6],
+    grass_pollen: [1.2, 1.7],
+    mugwort_pollen: [0.0, 0.0],
+    olive_pollen: [0.0, 0.0],
+    ragweed_pollen: [0.0, 0.0],
+  },
+});
+
+const buildOpenMeteoNoData = () => ({
+  hourly: {
+    alder_pollen: [null],
+    birch_pollen: [null],
+    grass_pollen: [null],
+    mugwort_pollen: [null],
+    olive_pollen: [null],
+    ragweed_pollen: [null],
+  },
+});
+
+const buildPollenComForecast = () => ({
+  Location: {
+    ZIP: '37206',
+    DisplayLocation: 'Nashville, TN',
+    periods: [
+      { Type: 'Yesterday', Index: 7.8, Triggers: [] },
+      {
+        Type: 'Today',
+        Index: 8.2,
+        Triggers: [
+          { LGID: 22, Name: 'Alder' },
+          { LGID: 272, Name: 'Juniper' },
+          { LGID: 4, Name: 'Maple' },
+        ],
+      },
+    ],
+  },
+});
+
+const formatIndexLabel = (index) => {
+  if (index <= 4.8) return 'Low';
+  if (index <= 7.2) return 'Medium';
+  if (index <= 9.6) return 'Medium-High';
+  return 'High';
+};
+
+describe('ollama-tools', () => {
+  let ollamaTools;
+  let mockRobot;
+  let mockRegistry;
+  let mockRegisteredTools;
+
+  before(function () {
+    // eslint-disable-next-line global-require
+    ollamaTools = require('../src/ollama-tools');
+  });
+
+  beforeEach(function () {
+    mockRegisteredTools = {};
+    mockRegistry = {
+      registerTool: sinon.spy((name, tool) => {
+        mockRegisteredTools[name] = tool;
+      }),
+    };
+
+    mockRobot = {
+      logger: {
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        error: sinon.stub(),
+      },
+    };
+
+    this.consoleStubs = {
+      log: sinon.stub(console, 'log'),
+      error: sinon.stub(console, 'error'),
+      warn: sinon.stub(console, 'warn'),
+    };
+  });
+
+  afterEach(function () {
+    delete process.env.HUBOT_POLLEN_OLLAMA_ENABLED;
+    Object.values(this.consoleStubs).forEach((stub) => stub.restore());
+  });
+
+  // ─── Enabled / disabled ────────────────────────────────────────────────────
+
+  it('skips registration when HUBOT_POLLEN_OLLAMA_ENABLED is not set', function () {
+    delete process.env.HUBOT_POLLEN_OLLAMA_ENABLED;
+
+    ollamaTools(mockRobot, {}, mockRegistry);
+
+    assert(mockRobot.logger.debug.calledWith(sinon.match(/disabled/i)));
+    assert.strictEqual(Object.keys(mockRegisteredTools).length, 0);
+  });
+
+  it('registers both tools when HUBOT_POLLEN_OLLAMA_ENABLED=true', function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: sinon.stub(),
+      getOpenMeteoForecast: sinon.stub(),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: sinon.stub(),
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: sinon.stub(),
+      formatIndexLabel: sinon.stub(),
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    assert('get_pollen_forecast' in mockRegisteredTools, 'get_pollen_forecast should be registered');
+    assert('get_pollen_by_coordinates' in mockRegisteredTools, 'get_pollen_by_coordinates should be registered');
+    assert(mockRegistry.registerTool.calledTwice);
+  });
+
+  // ─── get_pollen_forecast ───────────────────────────────────────────────────
+
+  it('get_pollen_forecast returns Open-Meteo data when available', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const geoLocation = {
+      name: 'London', latitude: 51.5, longitude: -0.1, country_code: 'GB',
+    };
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: (query, cb) => cb(null, geoLocation),
+      getOpenMeteoForecast: (loc, cb) => cb(null, buildOpenMeteoGoodForecast()),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: () => ({
+        intensity: 'Low',
+        topPeak: 1.7,
+        entries: [
+          { label: 'Grass', peak: 1.7 },
+          { label: 'Birch', peak: 0.6 },
+        ],
+        hasPositivePollen: true,
+      }),
+      buildOpenMeteoLocationLabel: () => 'London, GB',
+      extractFallbackZip: () => null,
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_forecast.handler({ location: 'London' });
+
+    assert.strictEqual(result.source, 'open-meteo');
+    assert.strictEqual(result.location, 'London, GB');
+    assert.strictEqual(result.intensity, 'Low');
+    assert.strictEqual(result.peak_grains_per_m3, 1.7);
+    assert.deepStrictEqual(result.pollen_types, [
+      { type: 'Grass', peak: 1.7 },
+      { type: 'Birch', peak: 0.6 },
+    ]);
+    assert.deepStrictEqual(result.coordinates, { latitude: 51.5, longitude: -0.1 });
+  });
+
+  it('get_pollen_forecast falls back to Pollen.com when Open-Meteo has no data', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const geoLocation = {
+      name: 'Nashville', latitude: 36.17, longitude: -86.78, country_code: 'US', admin1: 'Tennessee',
+    };
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: (query, cb) => cb(null, geoLocation),
+      getOpenMeteoForecast: (loc, cb) => cb(null, buildOpenMeteoNoData()),
+      getPollenForecastData: (zip, cb) => cb(null, buildPollenComForecast()),
+      summarizeOpenMeteoPollen: () => null,
+      buildOpenMeteoLocationLabel: () => 'Nashville, TN',
+      extractFallbackZip: () => '37206',
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_forecast.handler({ location: '37206' });
+
+    assert.strictEqual(result.source, 'pollen.com');
+    assert.strictEqual(result.location, 'Nashville, TN');
+    assert.strictEqual(result.zip, '37206');
+    assert.strictEqual(result.index, 8.2);
+    assert.strictEqual(result.level, 'Medium-High');
+    assert.deepStrictEqual(result.triggers, ['Alder', 'Juniper', 'Maple']);
+  });
+
+  it('get_pollen_forecast falls back to Pollen.com when geocoding fails but ZIP is in query', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const geocodeError = new Error('Open-Meteo could not geocode "37206"');
+    geocodeError.code = 'GEOCODE_NOT_FOUND';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: (query, cb) => cb(geocodeError),
+      getOpenMeteoForecast: sinon.stub(),
+      getPollenForecastData: (zip, cb) => cb(null, buildPollenComForecast()),
+      summarizeOpenMeteoPollen: sinon.stub(),
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: (query) => (/\b\d{5}\b/.test(query) ? query.match(/\b(\d{5})\b/)[1] : null),
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_forecast.handler({ location: '37206' });
+
+    assert.strictEqual(result.source, 'pollen.com');
+    assert.strictEqual(result.zip, '37206');
+  });
+
+  it('get_pollen_forecast rejects when geocoding fails and no ZIP fallback', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const geocodeError = new Error('Open-Meteo could not geocode "nowhere"');
+    geocodeError.code = 'GEOCODE_NOT_FOUND';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: (query, cb) => cb(geocodeError),
+      getOpenMeteoForecast: sinon.stub(),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: sinon.stub(),
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: () => null,
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    await assert.rejects(
+      () => mockRegisteredTools.get_pollen_forecast.handler({ location: 'nowhere' }),
+      (err) => {
+        assert(err.message.includes('Could not find location'));
+        return true;
+      },
+    );
+  });
+
+  it('get_pollen_forecast returns None intensity when Open-Meteo has no data and no fallback ZIP', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const geoLocation = {
+      name: 'Anchorage', latitude: 61.2, longitude: -149.9, country_code: 'US', admin1: 'Alaska',
+    };
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: (query, cb) => cb(null, geoLocation),
+      getOpenMeteoForecast: (loc, cb) => cb(null, buildOpenMeteoNoData()),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: () => null,
+      buildOpenMeteoLocationLabel: () => 'Anchorage, AK',
+      extractFallbackZip: () => null,
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_forecast.handler({ location: 'Anchorage, AK' });
+
+    assert.strictEqual(result.source, 'open-meteo');
+    assert.strictEqual(result.intensity, 'None');
+    assert.strictEqual(result.peak_grains_per_m3, 0);
+    assert.deepStrictEqual(result.pollen_types, []);
+  });
+
+  // ─── get_pollen_by_coordinates ─────────────────────────────────────────────
+
+  it('get_pollen_by_coordinates returns pollen data for valid coordinates', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: sinon.stub(),
+      getOpenMeteoForecast: (coords, cb) => cb(null, buildOpenMeteoGoodForecast()),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: () => ({
+        intensity: 'Low',
+        topPeak: 1.7,
+        entries: [
+          { label: 'Grass', peak: 1.7 },
+          { label: 'Birch', peak: 0.6 },
+        ],
+        hasPositivePollen: true,
+      }),
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: sinon.stub(),
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_by_coordinates.handler({
+      latitude: 51.5,
+      longitude: -0.1,
+    });
+
+    assert.strictEqual(result.source, 'open-meteo');
+    assert.deepStrictEqual(result.coordinates, { latitude: 51.5, longitude: -0.1 });
+    assert.strictEqual(result.intensity, 'Low');
+    assert.strictEqual(result.peak_grains_per_m3, 1.7);
+    assert.deepStrictEqual(result.pollen_types, [
+      { type: 'Grass', peak: 1.7 },
+      { type: 'Birch', peak: 0.6 },
+    ]);
+  });
+
+  it('get_pollen_by_coordinates returns None intensity when no pollen data', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: sinon.stub(),
+      getOpenMeteoForecast: (coords, cb) => cb(null, buildOpenMeteoNoData()),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: () => null,
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: sinon.stub(),
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    const result = await mockRegisteredTools.get_pollen_by_coordinates.handler({
+      latitude: 61.2,
+      longitude: -149.9,
+    });
+
+    assert.strictEqual(result.source, 'open-meteo');
+    assert.strictEqual(result.intensity, 'None');
+    assert.strictEqual(result.peak_grains_per_m3, 0);
+    assert.deepStrictEqual(result.pollen_types, []);
+  });
+
+  it('get_pollen_by_coordinates rejects on forecast error', async function () {
+    process.env.HUBOT_POLLEN_OLLAMA_ENABLED = 'true';
+
+    const mockFunctions = {
+      getOpenMeteoGeocode: sinon.stub(),
+      getOpenMeteoForecast: (coords, cb) => cb(new Error('HTTP 503')),
+      getPollenForecastData: sinon.stub(),
+      summarizeOpenMeteoPollen: sinon.stub(),
+      buildOpenMeteoLocationLabel: sinon.stub(),
+      extractFallbackZip: sinon.stub(),
+      formatIndexLabel,
+    };
+
+    ollamaTools(mockRobot, mockFunctions, mockRegistry);
+
+    await assert.rejects(
+      () => mockRegisteredTools.get_pollen_by_coordinates.handler({ latitude: 51.5, longitude: -0.1 }),
+      (err) => {
+        assert(err.message.includes('Could not retrieve pollen forecast'));
+        return true;
+      },
+    );
+  });
+});

--- a/test/pollen-slack-test.js
+++ b/test/pollen-slack-test.js
@@ -10,6 +10,29 @@ const helper = new Helper([
   '../src/pollen.js',
 ]);
 
+const buildOpenMeteoNoData = (latitude, longitude) => ({
+  latitude,
+  longitude,
+  hourly: {
+    alder_pollen: [null],
+    birch_pollen: [null],
+    grass_pollen: [null],
+    mugwort_pollen: [null],
+    olive_pollen: [null],
+    ragweed_pollen: [null],
+  },
+});
+
+const mockOpenMeteoGeocode = (name, result) => nock('https://geocoding-api.open-meteo.com')
+  .get('/v1/search')
+  .query((query) => query.name === `${name}`)
+  .reply(200, { results: [result] });
+
+const mockOpenMeteoAirQuality = (latitude, longitude, body) => nock('https://air-quality-api.open-meteo.com')
+  .get('/v1/air-quality')
+  .query((query) => Number(query.latitude) === latitude && Number(query.longitude) === longitude)
+  .reply(200, body);
+
 describe('hubot-pollen with slack adapter', () => {
   beforeEach(function () {
     process.env.HUBOT_LOG_LEVEL = 'error';
@@ -40,6 +63,16 @@ describe('hubot-pollen with slack adapter', () => {
   });
 
   it('responds to pollen forecast for default location', function (done) {
+    mockOpenMeteoGeocode('37206', {
+      name: 'Nashville',
+      latitude: 36.17,
+      longitude: -86.78,
+      postcodes: ['37206'],
+      country_code: 'US',
+      admin1: 'TN',
+    });
+    mockOpenMeteoAirQuality(36.17, -86.78, buildOpenMeteoNoData(36.17, -86.78));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/37206')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -100,6 +133,16 @@ describe('hubot-pollen with slack adapter', () => {
   });
 
   it('responds to pollen forecast plus a zip code', function (done) {
+    mockOpenMeteoGeocode('90210', {
+      name: 'Beverly Hills',
+      latitude: 34.09,
+      longitude: -118.41,
+      postcodes: ['90210'],
+      country_code: 'US',
+      admin1: 'CA',
+    });
+    mockOpenMeteoAirQuality(34.09, -118.41, buildOpenMeteoNoData(34.09, -118.41));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/90210')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -159,6 +202,16 @@ describe('hubot-pollen with slack adapter', () => {
   });
 
   it('responds to pollen forecast for a zip code with no results', function (done) {
+    mockOpenMeteoGeocode('99501', {
+      name: 'Anchorage',
+      latitude: 61.2,
+      longitude: -149.9,
+      postcodes: ['99501'],
+      country_code: 'US',
+      admin1: 'AK',
+    });
+    mockOpenMeteoAirQuality(61.2, -149.9, buildOpenMeteoNoData(61.2, -149.9));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/99501')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -173,6 +226,78 @@ describe('hubot-pollen with slack adapter', () => {
           assert.deepStrictEqual(selfRoom.messages, [
             ['alice', '@hubot pollen 99501'],
             ['hubot', '99501 Pollen: No forecast available.'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('responds with a Slack payload from Open-Meteo when pollen data is available', function (done) {
+    mockOpenMeteoGeocode('London', {
+      name: 'London',
+      latitude: 51.5,
+      longitude: -0.1,
+      country_code: 'GB',
+    });
+    mockOpenMeteoAirQuality(51.5, -0.1, {
+      latitude: 51.5,
+      longitude: -0.1,
+      hourly: {
+        alder_pollen: [0.0, 0.0],
+        birch_pollen: [0.1, 0.6],
+        grass_pollen: [1.2, 1.7],
+        mugwort_pollen: [0.0, 0.0],
+        olive_pollen: [0.0, 0.0],
+        ragweed_pollen: [0.0, 0.0],
+      },
+    });
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen London');
+    setTimeout(
+      () => {
+        try {
+          assert.strictEqual(selfRoom.messages[0][0], 'alice');
+          assert.strictEqual(selfRoom.messages[0][1], '@hubot pollen London');
+
+          const message = selfRoom.messages[1][1];
+          assert.strictEqual(selfRoom.messages[1][0], 'hubot');
+          assert(Array.isArray(message.attachments), 'Expected Slack attachments payload');
+          assert.strictEqual(message.attachments.length, 1);
+
+          const attachment = message.attachments[0];
+          assert.strictEqual(attachment.author_name, 'Open-Meteo');
+          assert.strictEqual(attachment.author_link, 'https://open-meteo.com/');
+          assert.strictEqual(attachment.color, 'warning');
+          assert.strictEqual(attachment.title, 'London, GB Pollen');
+          assert.strictEqual(attachment.title_link, 'https://open-meteo.com/en/docs/air-quality-api');
+          assert.strictEqual(
+            attachment.fallback,
+            'London, GB Pollen: Low intensity (1.7 grains/m^3 peak) - Grass 1.7, Birch 0.6',
+          );
+          assert.strictEqual(attachment.footer, 'Data: Open-Meteo');
+          assert.strictEqual(typeof attachment.ts, 'number');
+
+          assert.deepStrictEqual(attachment.fields, [
+            {
+              title: 'Intensity',
+              value: 'Low (Open-Meteo model scale)',
+              short: true,
+            },
+            {
+              title: 'Peak',
+              value: '1.7 grains/m^3',
+              short: true,
+            },
+            {
+              title: 'Types',
+              value: 'Grass 1.7, Birch 0.6',
+              short: false,
+            },
           ]);
           done();
         } catch (err) {

--- a/test/pollen-test.js
+++ b/test/pollen-test.js
@@ -9,6 +9,34 @@ const helper = new Helper([
   '../src/pollen.js',
 ]);
 
+const buildOpenMeteoNoData = (latitude, longitude) => ({
+  latitude,
+  longitude,
+  hourly: {
+    alder_pollen: [null],
+    birch_pollen: [null],
+    grass_pollen: [null],
+    mugwort_pollen: [null],
+    olive_pollen: [null],
+    ragweed_pollen: [null],
+  },
+});
+
+const mockOpenMeteoGeocode = (name, result) => nock('https://geocoding-api.open-meteo.com')
+  .get('/v1/search')
+  .query((query) => query.name === `${name}`)
+  .reply(200, { results: [result] });
+
+const mockOpenMeteoGeocodeQuery = (queryMatcher, body) => nock('https://geocoding-api.open-meteo.com')
+  .get('/v1/search')
+  .query(queryMatcher)
+  .reply(200, body);
+
+const mockOpenMeteoAirQuality = (latitude, longitude, body) => nock('https://air-quality-api.open-meteo.com')
+  .get('/v1/air-quality')
+  .query((query) => Number(query.latitude) === latitude && Number(query.longitude) === longitude)
+  .reply(200, body);
+
 describe('hubot-pollen', () => {
   beforeEach(function () {
     process.env.HUBOT_LOG_LEVEL = 'error';
@@ -39,6 +67,16 @@ describe('hubot-pollen', () => {
   });
 
   it('responds to pollen forecast for default location', function (done) {
+    mockOpenMeteoGeocode('37206', {
+      name: 'Nashville',
+      latitude: 36.17,
+      longitude: -86.78,
+      postcodes: ['37206'],
+      country_code: 'US',
+      admin1: 'TN',
+    });
+    mockOpenMeteoAirQuality(36.17, -86.78, buildOpenMeteoNoData(36.17, -86.78));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/37206')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -64,6 +102,16 @@ describe('hubot-pollen', () => {
   });
 
   it('responds to pollen forecast for default location with no allergens listed', function (done) {
+    mockOpenMeteoGeocode('37206', {
+      name: 'Nashville',
+      latitude: 36.17,
+      longitude: -86.78,
+      postcodes: ['37206'],
+      country_code: 'US',
+      admin1: 'TN',
+    });
+    mockOpenMeteoAirQuality(36.17, -86.78, buildOpenMeteoNoData(36.17, -86.78));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/37206')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -89,6 +137,16 @@ describe('hubot-pollen', () => {
   });
 
   it('responds to pollen forecast plus a zip code', function (done) {
+    mockOpenMeteoGeocode('90210', {
+      name: 'Beverly Hills',
+      latitude: 34.09,
+      longitude: -118.41,
+      postcodes: ['90210'],
+      country_code: 'US',
+      admin1: 'CA',
+    });
+    mockOpenMeteoAirQuality(34.09, -118.41, buildOpenMeteoNoData(34.09, -118.41));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/90210')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -114,6 +172,16 @@ describe('hubot-pollen', () => {
   });
 
   it('responds to pollen forecast for a zip code with no results', function (done) {
+    mockOpenMeteoGeocode('99501', {
+      name: 'Anchorage',
+      latitude: 61.2,
+      longitude: -149.9,
+      postcodes: ['99501'],
+      country_code: 'US',
+      admin1: 'AK',
+    });
+    mockOpenMeteoAirQuality(61.2, -149.9, buildOpenMeteoNoData(61.2, -149.9));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/99501')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -139,6 +207,16 @@ describe('hubot-pollen', () => {
   });
 
   it('handles a server error', function (done) {
+    mockOpenMeteoGeocode('37206', {
+      name: 'Nashville',
+      latitude: 36.17,
+      longitude: -86.78,
+      postcodes: ['37206'],
+      country_code: 'US',
+      admin1: 'TN',
+    });
+    mockOpenMeteoAirQuality(36.17, -86.78, buildOpenMeteoNoData(36.17, -86.78));
+
     nock('https://www.pollen.com')
       .get('/api/forecast/current/pollen/37206')
       .matchHeader('User-Agent', /Mozilla\/.*/)
@@ -169,6 +247,374 @@ describe('hubot-pollen', () => {
           done();
         } catch (err) {
           loggerErrorStub.restore();
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('responds from Open-Meteo when pollen data is available', function (done) {
+    mockOpenMeteoGeocode('London', {
+      name: 'London',
+      latitude: 51.5,
+      longitude: -0.1,
+      country_code: 'GB',
+    });
+    mockOpenMeteoAirQuality(51.5, -0.1, {
+      latitude: 51.5,
+      longitude: -0.1,
+      hourly: {
+        alder_pollen: [0.0, 0.0],
+        birch_pollen: [0.1, 0.6],
+        grass_pollen: [1.2, 1.7],
+        mugwort_pollen: [0.0, 0.0],
+        olive_pollen: [0.0, 0.0],
+        ragweed_pollen: [0.0, 0.0],
+      },
+    });
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen London');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen London'],
+            ['hubot', 'London, GB Pollen: Low intensity (1.7 grains/m^3 peak) - Grass 1.7, Birch 0.6'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('augments non-zip geocoding terms before failing', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'nashville, tn',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'nashville tn',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'nashville tn' && `${query.countryCode}`.toUpperCase() === 'US',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'nashville tennessee' && `${query.countryCode}`.toUpperCase() === 'US',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'nashville' && `${query.countryCode}`.toUpperCase() === 'US',
+      {
+        results: [
+          {
+            name: 'Nashville',
+            latitude: 36.17,
+            longitude: -86.78,
+            postcodes: ['37206'],
+            country_code: 'US',
+            admin1: 'TN',
+          },
+        ],
+      },
+    );
+
+    mockOpenMeteoAirQuality(36.17, -86.78, buildOpenMeteoNoData(36.17, -86.78));
+
+    nock('https://www.pollen.com')
+      .get('/api/forecast/current/pollen/37206')
+      .matchHeader('User-Agent', /Mozilla\/.*/)
+      .matchHeader('Referer', 'https://www.pollen.com/forecast/current/pollen/37206')
+      .replyWithFile(200, `${__dirname}/fixtures/37206.json`);
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen nashville, tn');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen nashville, tn'],
+            ['hubot', 'Nashville, TN Pollen: 8.2 (Medium-High) - Alder, Juniper, Maple'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('supports UK alias in geocoding augmentation', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london, uk',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london uk',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london gb' && `${query.countryCode}`.toUpperCase() === 'GB',
+      {
+        results: [
+          {
+            name: 'London',
+            latitude: 51.5,
+            longitude: -0.1,
+            country_code: 'GB',
+          },
+        ],
+      },
+    );
+
+    mockOpenMeteoAirQuality(51.5, -0.1, {
+      latitude: 51.5,
+      longitude: -0.1,
+      hourly: {
+        alder_pollen: [0.0, 0.0],
+        birch_pollen: [0.1, 0.6],
+        grass_pollen: [1.2, 1.7],
+        mugwort_pollen: [0.0, 0.0],
+        olive_pollen: [0.0, 0.0],
+        ragweed_pollen: [0.0, 0.0],
+      },
+    });
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen london, uk');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen london, uk'],
+            ['hubot', 'London, GB Pollen: Low intensity (1.7 grains/m^3 peak) - Grass 1.7, Birch 0.6'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('responds with a friendly message when geocoding cannot find a location', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london, uk',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london uk',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london gb' && `${query.countryCode}`.toUpperCase() === 'GB',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'london' && `${query.countryCode}`.toUpperCase() === 'GB',
+      { results: [] },
+    );
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen london, uk');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen london, uk'],
+            ['hubot', 'I couldn\'t find a location match for "london, uk". Try a simpler place name (for example, "London") or a 5-digit ZIP for US fallback.'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('responds with a friendly message when Open-Meteo has no usable data and no fallback zip exists', function (done) {
+    mockOpenMeteoGeocode('London', {
+      name: 'London',
+      latitude: 51.5,
+      longitude: -0.1,
+      country_code: 'GB',
+    });
+    mockOpenMeteoAirQuality(51.5, -0.1, buildOpenMeteoNoData(51.5, -0.1));
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen London');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen London'],
+            ['hubot', 'No usable Open-Meteo pollen forecast is currently available for London, GB. Try a nearby city or provide a postal code for fallback.'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('prioritizes country-constrained lookup for europe short codes', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'berlin de' && `${query.countryCode}`.toUpperCase() === 'DE',
+      {
+        results: [
+          {
+            name: 'Berlin',
+            latitude: 52.52,
+            longitude: 13.41,
+            country_code: 'DE',
+          },
+        ],
+      },
+    );
+
+    mockOpenMeteoAirQuality(52.52, 13.41, {
+      latitude: 52.52,
+      longitude: 13.41,
+      hourly: {
+        alder_pollen: [0.0, 0.0],
+        birch_pollen: [1.5, 3.5],
+        grass_pollen: [1.1, 2.2],
+        mugwort_pollen: [0.0, 0.0],
+        olive_pollen: [0.0, 0.1],
+        ragweed_pollen: [0.0, 0.0],
+      },
+    });
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen berlin, de');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen berlin, de'],
+            ['hubot', 'Berlin, DE Pollen: Low intensity (3.5 grains/m^3 peak) - Birch 3.5, Grass 2.2, Olive 0.1'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('supports europe country names as constrained lookups', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'berlin de' && `${query.countryCode}`.toUpperCase() === 'DE',
+      {
+        results: [
+          {
+            name: 'Berlin',
+            latitude: 52.52,
+            longitude: 13.41,
+            country_code: 'DE',
+          },
+        ],
+      },
+    );
+
+    mockOpenMeteoAirQuality(52.52, 13.41, {
+      latitude: 52.52,
+      longitude: 13.41,
+      hourly: {
+        alder_pollen: [0.0, 0.0],
+        birch_pollen: [1.5, 3.5],
+        grass_pollen: [1.1, 2.2],
+        mugwort_pollen: [0.0, 0.0],
+        olive_pollen: [0.0, 0.1],
+        ragweed_pollen: [0.0, 0.0],
+      },
+    });
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen berlin, germany');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen berlin, germany'],
+            ['hubot', 'Berlin, DE Pollen: Low intensity (3.5 grains/m^3 peak) - Birch 3.5, Grass 2.2, Olive 0.1'],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      100,
+    );
+  });
+
+  it('does not accept wrong-state matches for US city,state queries', function (done) {
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'oneida tx' && `${query.countryCode}`.toUpperCase() === 'US',
+      {
+        results: [
+          {
+            name: 'Oneida',
+            latitude: 43.09,
+            longitude: -75.65,
+            postcodes: ['13421'],
+            country_code: 'US',
+            admin1: 'New York',
+          },
+        ],
+      },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'oneida texas' && `${query.countryCode}`.toUpperCase() === 'US',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'oneida' && `${query.countryCode}`.toUpperCase() === 'US',
+      {
+        results: [
+          {
+            name: 'Oneida',
+            latitude: 43.09,
+            longitude: -75.65,
+            postcodes: ['13421'],
+            country_code: 'US',
+            admin1: 'New York',
+          },
+        ],
+      },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'oneida, tx',
+      { results: [] },
+    );
+    mockOpenMeteoGeocodeQuery(
+      (query) => `${query.name}`.toLowerCase() === 'oneida tx',
+      { results: [] },
+    );
+
+    const selfRoom = this.room;
+    selfRoom.user.say('alice', '@hubot pollen oneida, tx');
+    setTimeout(
+      () => {
+        try {
+          assert.deepStrictEqual(selfRoom.messages, [
+            ['alice', '@hubot pollen oneida, tx'],
+            ['hubot', 'I couldn\'t find a location match for "oneida, tx". Try a simpler place name (for example, "London") or a 5-digit ZIP for US fallback.'],
+          ]);
+          done();
+        } catch (err) {
           done(err);
         }
       },


### PR DESCRIPTION
This pull request introduces support for Ollama integration, improves documentation, and updates the npm publishing workflow. The most important changes include adding new Ollama tool definitions for pollen data, enhancing the `README.md` to describe the new features and usage, and updating the GitHub Actions workflow for publishing to npm.

**Ollama Integration:**

* Added a new file `src/ollama-tools.js` that registers two tools—`get_pollen_forecast` and `get_pollen_by_coordinates`—for use with the `hubot-ollama` package, allowing LLM-powered conversations to access pollen data. The tools use Open-Meteo as the primary source and fall back to Pollen.com when needed.

**Documentation Updates:**

* Updated `README.md` to describe the new data source strategy (Open-Meteo with fallback to Pollen.com), configuration options, supported commands, Ollama tool integration, and provided example API responses. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R143)

**CI/CD Improvements:**

* Updated `.github/workflows/npm-publish.yml` to use newer versions of GitHub Actions, enable OIDC publishing, and add a step to update npm to the latest version, improving publishing reliability and security.